### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-##Angular2 Tuber
-#####*Search/Filter/Sort YouTube Videos Instantly*
+## Angular2 Tuber
+##### *Search/Filter/Sort YouTube Videos Instantly*
 
-###Live Demo of Angular2 Tuber
+### Live Demo of Angular2 Tuber
 [Angular2 Tuber online!](https://angular2-youtuber.firebaseapp.com/)
 
-####vs React Version of Tuber
+#### vs React Version of Tuber
 * [React Tuber online!](https://tuber.firebaseapp.com/)
 * [React Source Code](https://github.com/alexhawkins/tuber)
 
-#####*Which one do you think is faster?*
+##### *Which one do you think is faster?*
 
-###Technologies Used
+### Technologies Used
   * Angular2 (ES6)
   * Bootstrap
   * YouTube API
 
-###SETUP:
+### SETUP:
   * Fork this repo and clone your fork
   * `npm install`
   * `npm start`
@@ -27,9 +27,9 @@ Created by [Alex Hawkins](https://twitter.com/alexchawkins) - April 2015
 
 #### *Special Thanks*:
 
-###[@kentcdodds](https://twitter.com/kentcdodds)
+### [@kentcdodds](https://twitter.com/kentcdodds)
 
-###[@gdi2290](https://twitter.com/gdi2290) (aka [PatrickJS](https://github.com/gdi2290))
+### [@gdi2290](https://twitter.com/gdi2290) (aka [PatrickJS](https://github.com/gdi2290))
 
 *This project would not have been possible without their awesome Angular2 projects:* 
 * [ng2-RandomUser](https://github.com/kentcdodds/ng2-random-user)

--- a/dist/lib/README.md
+++ b/dist/lib/README.md
@@ -1,5 +1,5 @@
-#[Font Awesome v4.3.0](http://fontawesome.io)
-###The iconic font and CSS framework
+# [Font Awesome v4.3.0](http://fontawesome.io)
+### The iconic font and CSS framework
 
 Font Awesome is a full suite of 519 pictographic icons for easy scalable vector graphics on websites,
 created and maintained by [Dave Gandy](http://twitter.com/davegandy).
@@ -8,7 +8,7 @@ Stay up to date with the latest release and announcements on Twitter:
 
 Get started at http://fontawesome.io!
 
-##License
+## License
 - The Font Awesome font is licensed under the SIL OFL 1.1:
   - http://scripts.sil.org/OFL
 - Font Awesome CSS, LESS, and Sass files are licensed under the MIT License:
@@ -19,7 +19,7 @@ Get started at http://fontawesome.io!
   - `Font Awesome by Dave Gandy - http://fontawesome.io`
 - Full details: http://fontawesome.io/license
 
-##Changelog
+## Changelog
 - v3.0.0 - all icons redesigned from scratch, optimized for Bootstrap's 14px default
 - v3.0.1 - much improved rendering in webkit, various bug fixes
 - v3.0.2 - much improved rendering and alignment in IE7
@@ -40,7 +40,7 @@ Get started at http://fontawesome.io!
 Please read through our [contributing guidelines](https://github.com/FortAwesome/Font-Awesome/blob/master/CONTRIBUTING.md).
 Included are directions for opening issues, coding standards, and notes on development.
 
-##Versioning
+## Versioning
 
 Font Awesome will be maintained under the Semantic Versioning guidelines as much as possible. Releases will be numbered
 with the following format:
@@ -55,12 +55,12 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org.
 
-##Author
+## Author
 - Email: dave@fontawesome.io
 - Twitter: http://twitter.com/davegandy
 - GitHub: https://github.com/davegandy
 
-##Component
+## Component
 To include as a [component](http://github.com/component/component), just run
 
     $ component install FortAwesome/Font-Awesome


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
